### PR TITLE
Fix linter errors and improvements to reliability

### DIFF
--- a/cometblue_lite/cometblue.py
+++ b/cometblue_lite/cometblue.py
@@ -7,16 +7,11 @@ Currently only current and target temperature in manual mode is supported, nothi
 Parts were taken from the cometblue module by im-0
 """
 import logging
-from datetime import timedelta
-from datetime import datetime
-
-import time
 import struct
 
 from bluepy import btle
 
 _LOGGER = logging.getLogger(__name__)
-_LOGGER.setLevel(10)
 
 COMETBLUE_SERVICE = "47E9EE00-47E9-11E4-8939-164230D1DF67"
 PASSWORD_CHAR = "47e9ee30-47e9-11e4-8939-164230d1df67"
@@ -44,9 +39,50 @@ _STATUS_BITMASKS = {
     'unknown': 0x2000
 }
 
+def _decode_status(value):
+    state_bytes = struct.unpack(_STATUS_STRUCT_PACKING, value)
+    state_dword = struct.unpack('<I', value + b'\x00')[0]
+
+    report = {}
+    masked_out = 0
+    for key, mask in _STATUS_BITMASKS.items():
+        report[key] = bool(state_dword & mask == mask)
+        masked_out |= mask
+
+    report['state_as_dword'] = state_dword
+    report['unused_bits'] = state_dword & ~masked_out
+
+    return report
+
+
+def _encode_status(value):
+    status_dword = 0
+    for key, state in value.items():
+        if not state:
+            continue
+        if key not in _STATUS_BITMASKS:
+            continue
+        status_dword |= _STATUS_BITMASKS[key]
+    value = struct.pack('<I', status_dword)
+    # downcast to 3 bytes
+    return struct.pack(_STATUS_STRUCT_PACKING, *[int(byte) for byte in value[:3]])
+
+
+def _encode_datetime(dt):
+    if dt.year < 2000:
+        raise RuntimeError('Invalid year')
+    return struct.pack(
+        _DATETIME_STRUCT_PACKING,
+        dt.minute,
+        dt.hour,
+        dt.day,
+        dt.month,
+        dt.year - 2000)
+
 
 class CometBlue(object):
     """CometBlue Thermostat """
+
     def __init__(self, address, pin):
         super(CometBlue, self).__init__()
         self._address = address
@@ -61,42 +97,47 @@ class CometBlue(object):
         self._status = dict()
         self._handles = dict()
         self._model = None
-#        self.update()
 
     def connect(self):
         """Connect to thermostat and send PIN"""
+        _LOGGER.debug("Connecting to device %s", self._address)
+
         try:
             self._conn.connect(self._address)
-        except btle.BTLEException as ex:
-            _LOGGER.debug("Unable to connect to the device %s, retrying: %s", self._address, ex)
+        except btle.BTLEException as exc:
+            _LOGGER.debug("Unable to connect to the device %s, retrying.", self._address, exc_info=exc)
             try:
                 self._conn.connect(self._address)
-            except Exception as ex2:
-                _LOGGER.debug("Second connection try to %s failed: %s", self._address, ex2)
+            except btle.BTLEException as exc:
+                _LOGGER.debug("Second connection try to %s failed.", self._address, exc_info=exc)
                 raise
-        if len(self._handles) <= 0:
+
+        if len(self._handles) == 0:
+            _LOGGER.debug("Discovering characteristics %s", self._address)
             try:
-                _LOGGER.debug("discovering characteristics %s", self._address)
                 service = self._conn.getServiceByUUID(COMETBLUE_SERVICE)
                 chars = service.getCharacteristics()
                 self._handles = {str(a.uuid): a.getHandle() for a in chars}
-            except btle.BTLEException as ex:
-                _LOGGER.debug("could not discover characteristics %s: %s", self._address, ex2)
+            except btle.BTLEException as exc:
+                _LOGGER.debug("Could not discover characteristics %s", self._address, exc_info=exc)
                 raise
+
+        # authenticate with PIN and initialize static values
         try:
-            self._conn.writeCharacteristic(self._handles[PASSWORD_CHAR], struct.pack(_PIN_STRUCT_PACKING, self._pin), withResponse=True)
-        except:
-            _LOGGER.info("could not write provided pin, trying 000000 %s", self._address)
-            self._conn.writeCharacteristic(self._handles[PASSWORD_CHAR], struct.pack(_PIN_STRUCT_PACKING, 0), withResponse=True)
-            
+            data = struct.pack(_PIN_STRUCT_PACKING, self._pin)
+            self._conn.writeCharacteristic(self._handles[PASSWORD_CHAR], data, withResponse=True)
+        except btle.BTLEException as exc:
+            _LOGGER.debug("Can't set PIN for device %s. Is pin=%s correct?", self._address, self._pin,
+                          exc_info=exc)
+            raise
 
     def disconnect(self):
         """Disconnect from thermostat"""
         self._conn.disconnect()
-        self._conn = btle.Peripheral()
+        _LOGGER.debug("Disconnected from device %s", self._address)
 
     def should_update(self):
-        return self._temperature != None or len(self._new_status)>0
+        return self._temperature is not None or len(self._new_status) > 0
 
     @property
     def manual_temperature(self):
@@ -104,13 +145,13 @@ class CometBlue(object):
             return self._manual_temp / 2.0
         else:
             return None
- 
+
     @property
     def current_temperature(self):
         if self._cur_temp:
             return self._cur_temp / 2.0
         else:
-            return None 
+            return None
 
     @property
     def model(self):
@@ -119,7 +160,7 @@ class CometBlue(object):
     @property
     def battery_level(self):
         return self._batt_level
-    
+
     @property
     def manual_mode(self):
         if self._status:
@@ -127,52 +168,52 @@ class CometBlue(object):
         else:
             return None
 
-
     def update(self):
         """Communicate with device"""
-        _LOGGER.debug("Connecting to device %s", self._address)
         try:
             self.connect()
-            if not self._model:
+
+            if self._model is None:
                 self._model = str(self._conn.readCharacteristic(self._handles[MODEL_CHAR]))
-                
+
             data = self._conn.readCharacteristic(self._handles[TEMPERATURE_CHAR])
-            self._cur_temp, self._manual_temp, self._target_low, self._target_high, self._offset_temp, \
-                    self._window_open_detect, self._window_open_minutes = struct.unpack(
-                            _TEMPERATURES_STRUCT_PACKING, data)
+            self._cur_temp, self._manual_temp, _, _, _, _, _ = struct.unpack(_TEMPERATURES_STRUCT_PACKING, data)
+
             data = self._conn.readCharacteristic(self._handles[STATUS_CHAR])
-            self._status = CometBlue._decode_status(data)
-            _LOGGER.debug("Status: %s", self._status)
-            bat_data = self._conn.readCharacteristic(self._handles[BATTERY_CHAR])
-            self._batt_level = ord(bat_data)
-            if self._batt_level:
-                _LOGGER.debug("Updating Battery level for device %s to %d", self._address, self._batt_level)
+            decoded_status = _decode_status(data)
+            if self._status != decoded_status:
+                self._status = decoded_status
+                _LOGGER.debug("Status: %s", self._status)
 
             if self._temperature:
-                _LOGGER.debug("Updating Temperature for device %s to %d", self._address, self._temperature)
+                _LOGGER.debug("Updating Temperature for device %s to %.f", self._address, self._temperature)
                 self.write_temperature()
-            if len(self._new_status)>0:
+
+            if len(self._new_status) > 0:
                 _LOGGER.debug("Updating Status for device %s", self._address)
                 self.write_status()
-            self.available = True
 
-        except btle.BTLEGattError:
-            _LOGGER.error("Can't read cometblue data (%s). Did you set the correct PIN?", self._address)
+            bat_data = ord(self._conn.readCharacteristic(self._handles[BATTERY_CHAR]))
+            if self._batt_level != bat_data:
+                self._batt_level = bat_data
+                _LOGGER.debug("Battery level: %s", self._batt_level)
+        except btle.BTLEGattError as exc:
+            _LOGGER.error("Can't read/write cometblue data (%s). Did you set the correct PIN?", self._address,
+                          exc_info=exc)
             self.available = False
-            #raise
-        except btle.BTLEDisconnectError:
-            _LOGGER.error("Can't connect to cometblue (%s). Did you set the correct PIN?", self._address)
+        except btle.BTLEException as exc:
+            _LOGGER.error("Can't connect to cometblue (%s). Did you set the correct PIN?", self._address, exc_info=exc)
             self.available = False
-            #raise
+        else:
+            self.available = True
         finally:
             self.disconnect()
-            _LOGGER.debug("Disconnected from device %s", self._address)
 
     @manual_temperature.setter
     def manual_temperature(self, temperature):
         """Set manual temperature. Call update() afterwards"""
         self._temperature = temperature
-    
+
     @manual_mode.setter
     def manual_mode(self, mode):
         """set manual/auto mode. Call update() afterwards"""
@@ -181,59 +222,18 @@ class CometBlue(object):
     def write_temperature(self):
         self._manual_temp = int(self._temperature * 2.0)
         data = struct.pack(
-                    _TEMPERATURES_STRUCT_PACKING,
-                    -128, self._manual_temp,
-                    -128, -128, -128, -128, -128)
-        self._conn.writeCharacteristic(self._handles[TEMPERATURE_CHAR],data)
-        
+            _TEMPERATURES_STRUCT_PACKING,
+            -128, self._manual_temp,
+            -128, -128, -128, -128, -128)
+        self._conn.writeCharacteristic(self._handles[TEMPERATURE_CHAR], data)
         self._temperature = None
-    
+
     def write_status(self):
         status = self._status.copy()
         status.update(self._new_status)
-        _LOGGER.debug("new status %s", status)
-        
-        data = CometBlue._encode_status(status)
-        self._conn.writeCharacteristic(self._handles[STATUS_CHAR],data)
+        _LOGGER.debug("Updating Status for device {} to {}".format(self._address, status))
+
+        data = _encode_status(status)
+        self._conn.writeCharacteristic(self._handles[STATUS_CHAR], data)
         self._status = status
-        
         self._new_status = dict()
-
-    def _decode_status(value):
-        state_bytes = struct.unpack(_STATUS_STRUCT_PACKING, value)
-        state_dword = struct.unpack('<I', value + b'\x00')[0]
-
-        report = {}
-        masked_out = 0
-        for key, mask in _STATUS_BITMASKS.items():
-            report[key] = bool(state_dword & mask == mask)
-            masked_out |= mask
-
-        report['state_as_dword'] = state_dword
-        report['unused_bits'] = state_dword & ~masked_out
-
-        return report
-
-
-    def _encode_status(value):
-        status_dword = 0
-        for key, state in value.items():
-            if not state:
-                continue
-            if not key in _STATUS_BITMASKS:
-                continue
-            status_dword |= _STATUS_BITMASKS[key]
-        value = struct.pack('<I', status_dword)
-        # downcast to 3 bytes
-        return struct.pack(_STATUS_STRUCT_PACKING, *[int(byte) for byte in value[:3]])
-
-    def _encode_datetime(dt):
-        if dt.year < 2000:
-            raise RuntimeError('Invalid year')
-        return struct.pack(
-                _DATETIME_STRUCT_PACKING,
-                dt.minute,
-                dt.hour,
-                dt.day,
-                dt.month,
-                dt.year - 2000)

--- a/setup.py
+++ b/setup.py
@@ -3,15 +3,13 @@ from setuptools import setup
 
 setup(
     name='cometblue_lite',
-    version='0.2',
+    version='0.3-rc1',
     packages=['cometblue_lite'],
     python_requires='>=3.4',
     install_requires=['bluepy>=1.3'],
     description='Module for Eurotronic Comet Blue thermostats',
     author='David Kreitschmann',
-#    author_email='neffs1@gmail.com',
     maintainer='David Kreitschmann',
-#    maintainer_email='neffs1@gmail.com',
     url='https://github.com/neffs/python-cometblue-lite',
     license="MIT",
     classifiers=[
@@ -20,10 +18,4 @@ setup(
             "Operating System :: POSIX :: Linux",
             "Development Status :: 3 - Alpha",
         ],
-    
-#    entry_points={
-#        'console_scripts': [
-#            'cblitecli = cometblue-lite.cbcli:cli'
-#        ]
-#    }
 )


### PR DESCRIPTION
Hi,

I did a cleanup of the codebase, because my PyCharm was constantly warning about the style errors.
In the first commit, I tried to leave logic as is, just fix linter errors, code order for better readability and minor improvements to the logging by using the `exc_info` field.

In the second commit, I implemented some code order-changes and exception handling to improve the reliability in regard to bluetooth-errors.