### PR TITLE
feat: Divide device state into current and target

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,21 @@
 This is a very basic library for communicating with a Comet Blue thermostat or other compatible thermostats, such as Xavax, Silvercrest, ...
 It was written with home assistant in mind. 
 
-The full cometblue module has more features, but uses another bluetooth library, which may not always be usable. 
+The full cometblue module has more features, but uses another bluetooth library, which may not always be usable.
+
+## what works
+
+Feature | Get | Set
+------- | ------- | ------
+Mode | :heavy_check_mark: | :heavy_check_mark:
+Childlock | :heavy_multiplication_x: | :heavy_multiplication_x:
+Target Temperature | :heavy_check_mark: | :heavy_check_mark:
+Current Temperature | :heavy_check_mark: | :heavy_minus_sign:
+Open Window Detection | :heavy_multiplication_x: | :heavy_multiplication_x:
+Holiday | :heavy_multiplication_x: | :heavy_multiplication_x:
+Battery Level | :heavy_check_mark: | :heavy_minus_sign:
+Low Battery | :heavy_multiplication_x: | :heavy_minus_sign:
+Model | :heavy_check_mark: | :heavy_minus_sign:
+Manufacturer Name | :heavy_multiplication_x: | :heavy_minus_sign:
+Firmware Rev. | :heavy_multiplication_x: | :heavy_minus_sign:
+Software Rev. | :heavy_multiplication_x: | :heavy_minus_sign: 

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 
 setup(
     name='cometblue_lite',
-    version='0.3-rc1',
+    version='0.3-rc2',
     packages=['cometblue_lite'],
     python_requires='>=3.4',
     install_requires=['bluepy>=1.3'],


### PR DESCRIPTION
As seen in https://github.com/Hy3n4/ha-cc-cometblue, I divided the
current and target device state. This improves readability and eases
the addition of further states. Some are already prepared.

Change "manual_temp" to a more appropriate "target_temperature".

Based on this, I've already prepared the addition of more states and functions, coming up in other PRs. The changes for the ha-component will then follow suit.