### PR TITLE
Fix: Property "model" had name collision

### DIFF
--- a/cometblue_lite/cometblue.py
+++ b/cometblue_lite/cometblue.py
@@ -329,10 +329,6 @@ class CometBlue:
         self._target.offset_temperature = temperature
 
     @property
-    def model(self):
-        return self._current.model
-
-    @property
     def battery_level(self):
         return self._current.battery_level
 


### PR DESCRIPTION
Copy & paste mistake while reordering the properties by name. Should
have been a cut & paste operation.